### PR TITLE
fix: instantiate readable stream error

### DIFF
--- a/lib/reply.js
+++ b/lib/reply.js
@@ -681,7 +681,7 @@ function logStreamError (logger, err, res) {
 
 function sendWebStream (payload, res, reply) {
   if (payload.locked) {
-    throw FST_ERR_REP_READABLE_STREAM_LOCKED()
+    throw new FST_ERR_REP_READABLE_STREAM_LOCKED()
   }
   const nodeStream = Readable.fromWeb(payload)
   sendStream(nodeStream, res, reply)

--- a/test/reply-web-stream-locked.test.js
+++ b/test/reply-web-stream-locked.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const t = require('tap')
+const Fastify = require('..')
+const { ReadableStream } = require('stream/web')
+
+t.test('reply.send(web ReadableStream) throws if locked', async t => {
+  const app = Fastify()
+
+  app.get('/', async (req, reply) => {
+    const rs = new ReadableStream({
+      start (controller) { controller.enqueue(new TextEncoder().encode('hi')); controller.close() }
+    })
+    // lock the stream
+    const reader = rs.getReader()
+    t.ok(rs.locked, 'stream is locked')
+
+    // sending a locked stream should trigger the Fastify error
+    reply.send(rs)
+    await reader.releaseLock()
+  })
+
+  const res = await app.inject({ method: 'GET', url: '/' })
+  t.equal(res.statusCode, 500)
+  t.match(res.body, /locked/i) // message mentions "locked"
+  await app.close()
+})


### PR DESCRIPTION
#### Description
Instantiate `FST_ERR_REP_READABLE_STREAM_LOCKED` with `new` in `sendWebStream`, matching other thrown Fastify errors.

#### Checklist
- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests are included (see `test/reply-web-stream-locked.test.js`)
- [ ] documentation N/A
- [x] commit follows DCO and code of conduct
