### PR TITLE
fix(content-type-parser): trim leading spaces

### DIFF
--- a/lib/contentTypeParser.js
+++ b/lib/contentTypeParser.js
@@ -108,6 +108,7 @@ ContentTypeParser.prototype.existingParser = function (contentType) {
 }
 
 ContentTypeParser.prototype.getParser = function (contentType) {
+  contentType = contentType.trim()
   let parser = this.customParsers.get(contentType)
   if (parser !== undefined) return parser
   parser = this.cache.get(contentType)

--- a/test/content-parser.test.js
+++ b/test/content-parser.test.js
@@ -74,9 +74,9 @@ test('getParser', async t => {
     t.assert.strictEqual(fastify[keys.kContentTypeParser].getParser('text/html').fn, first)
     t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 0)
     t.assert.strictEqual(fastify[keys.kContentTypeParser].getParser('text/html ').fn, first)
-    t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 1)
+    t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 0)
     t.assert.strictEqual(fastify[keys.kContentTypeParser].getParser('text/html ').fn, first)
-    t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 1)
+    t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 0)
   })
 
   await t.test('should return matching parser with caching /2', t => {
@@ -109,6 +109,15 @@ test('getParser', async t => {
     t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 2)
     t.assert.strictEqual(fastify[keys.kContentTypeParser].getParser('text/html;charset=utf-8').fn, first)
     t.assert.strictEqual(fastify[keys.kContentTypeParser].cache.size, 2)
+  })
+
+  await t.test('should return matching parser for leading spaces', t => {
+    t.plan(1)
+
+    const fastify = Fastify()
+    const ctp = fastify[keys.kContentTypeParser]
+    const baseParser = ctp.getParser('application/json')
+    t.assert.strictEqual(ctp.getParser('  application/json')?.fn, baseParser.fn)
   })
 
   await t.test('should prefer content type parser with string value', t => {


### PR DESCRIPTION
## Summary
- handle leading whitespace in Content-Type header so default parser is used
- expand content parser tests for leading spaces and adjust caching expectations

## Testing
- `npm run lint lib/contentTypeParser.js test/content-parser.test.js`
- `node --test test/content-parser.test.js`